### PR TITLE
Add Faraday and HTTParty patch tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,21 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    csv (3.3.5)
     date (3.4.1)
     drb (2.2.3)
     erb (5.0.1)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     hashdiff (1.2.0)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -54,9 +65,14 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    mini_mime (1.1.5)
     minitest (5.25.5)
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
+    net-http (0.6.0)
+      uri
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -125,6 +141,7 @@ GEM
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     sqlite3 (2.7.0-arm64-darwin)
+    sqlite3 (2.7.0-x86_64-linux-gnu)
     stringio (3.1.7)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -140,8 +157,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
+  faraday (~> 2.0)
+  httparty (~> 0.20)
   irb
   minitest (~> 5.0)
   mocha (~> 2.0)

--- a/outbound_http_logger.gemspec
+++ b/outbound_http_logger.gemspec
@@ -38,6 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-thread_safety", "~> 0.7"
   spec.add_development_dependency "sqlite3", ">= 2.1"
   spec.add_development_dependency "webmock", "~> 3.0"
+  spec.add_development_dependency "faraday", "~> 2.0"
+  spec.add_development_dependency "httparty", "~> 0.20"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/test/patches/test_faraday_patch.rb
+++ b/test/patches/test_faraday_patch.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "faraday"
+
+describe "Faraday Patch" do
+  before do
+    OutboundHttpLogger::Patches::FaradayPatch.apply!
+  end
+
+  describe "when logging is enabled" do
+    before do
+      OutboundHttpLogger.enable!
+    end
+
+    it "logs successful GET requests" do
+      stub_request(:get, "https://api.example.com/users")
+        .to_return(status: 200, body: '{"users": []}', headers: { 'Content-Type' => 'application/json' })
+
+      connection = Faraday.new
+      response   = connection.get("https://api.example.com/users")
+
+      _(response.status).must_equal 200
+
+      log = assert_request_logged(:get, "https://api.example.com/users", 200)
+      _(log.response_body).must_equal '{"users":[]}'
+      _(log.duration_ms).must_be :>, 0
+    end
+
+    it "logs POST requests with request body" do
+      stub_request(:post, "https://api.example.com/users")
+        .with(body: '{"name": "John"}', headers: { 'Content-Type' => 'application/json' })
+        .to_return(status: 201, body: '{"id": 1, "name": "John"}', headers: { 'Content-Type' => 'application/json' })
+
+      connection = Faraday.new(headers: { 'Content-Type' => 'application/json' })
+      response   = connection.post("https://api.example.com/users", '{"name": "John"}')
+
+      _(response.status).must_equal 201
+
+      log = assert_request_logged(:post, "https://api.example.com/users", 201)
+      _(log.request_body).must_equal '{"name":"John"}'
+      _(log.response_body).must_equal '{"id":1,"name":"John"}'
+    end
+
+    it "logs requests with headers" do
+      stub_request(:get, "https://api.example.com/protected")
+        .with(headers: { 'Authorization' => 'Bearer token123' })
+        .to_return(status: 200, body: '{"data": "secret"}', headers: { 'Content-Type' => 'application/json' })
+
+      connection = Faraday.new
+      response   = connection.get("https://api.example.com/protected") do |req|
+        req.headers['Authorization'] = 'Bearer token123'
+      end
+
+      _(response.status).must_equal 200
+
+      log = assert_request_logged(:get, "https://api.example.com/protected", 200)
+      _(log.request_headers['authorization']).must_equal '[FILTERED]'
+    end
+
+    it "logs failed requests" do
+      stub_request(:get, "https://api.example.com/notfound")
+        .to_return(status: 404, body: '{"error": "Not found"}', headers: { 'Content-Type' => 'application/json' })
+
+      connection = Faraday.new
+      response   = connection.get("https://api.example.com/notfound")
+
+      _(response.status).must_equal 404
+
+      log = assert_request_logged(:get, "https://api.example.com/notfound", 404)
+      _(log.response_body).must_equal '{"error":"Not found"}'
+    end
+
+    it "skips excluded URLs" do
+      stub_request(:get, "https://api.example.com/health")
+        .to_return(status: 200, body: 'OK')
+
+      connection = Faraday.new
+      response   = connection.get("https://api.example.com/health")
+
+      _(response.status).must_equal 200
+      assert_no_request_logged
+    end
+
+    it "skips excluded content types" do
+      stub_request(:get, "https://api.example.com/page")
+        .to_return(status: 200, body: '<html></html>', headers: { 'Content-Type' => 'text/html' })
+
+      connection = Faraday.new
+      response   = connection.get("https://api.example.com/page")
+
+      _(response.status).must_equal 200
+      assert_no_request_logged
+    end
+
+    it "handles network errors gracefully" do
+      stub_request(:get, "https://api.example.com/error")
+        .to_raise(SocketError.new("Connection failed"))
+
+      connection = Faraday.new
+
+      _(proc { connection.get("https://api.example.com/error") }).must_raise Faraday::ConnectionFailed
+
+      log = assert_request_logged(:get, "https://api.example.com/error", 0)
+      _(log.response_body).must_include "SocketError"
+    end
+
+    it "prevents infinite recursion" do
+      stub_request(:get, "https://api.example.com/test")
+        .to_return(status: 200, body: 'OK')
+
+      connection = Faraday.new
+      3.times do
+        response = connection.get("https://api.example.com/test")
+        _(response.status).must_equal 200
+      end
+
+      logs = OutboundHttpLogger::Models::OutboundRequestLog.where(url: "https://api.example.com/test")
+      _(logs.count).must_equal 6
+    end
+  end
+
+  describe "when logging is disabled" do
+    before do
+      OutboundHttpLogger.disable!
+    end
+
+    it "does not log requests when disabled" do
+      stub_request(:get, "https://api.example.com/users")
+        .to_return(status: 200, body: '{"users": []}')
+
+      connection = Faraday.new
+      response   = connection.get("https://api.example.com/users")
+
+      _(response.status).must_equal 200
+      assert_no_request_logged
+    end
+  end
+end

--- a/test/patches/test_httparty_patch.rb
+++ b/test/patches/test_httparty_patch.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "httparty"
+
+describe "HTTParty Patch" do
+  before do
+    OutboundHttpLogger::Patches::HttppartyPatch.apply!
+  end
+
+  describe "when logging is enabled" do
+    before do
+      OutboundHttpLogger.enable!
+    end
+
+    it "logs successful GET requests" do
+      stub_request(:get, "https://api.example.com/users")
+        .to_return(status: 200, body: '{"users": []}', headers: { 'Content-Type' => 'application/json' })
+
+      response = HTTParty.get("https://api.example.com/users")
+
+      _(response.code).must_equal 200
+
+      log = assert_request_logged(:get, "https://api.example.com/users", 200)
+      _(log.response_body).must_equal '{"users":[]}'
+      _(log.duration_ms).must_be :>, 0
+    end
+
+    it "logs POST requests with request body" do
+      stub_request(:post, "https://api.example.com/users")
+        .with(body: '{"name": "John"}', headers: { 'Content-Type' => 'application/json' })
+        .to_return(status: 201, body: '{"id": 1, "name": "John"}', headers: { 'Content-Type' => 'application/json' })
+
+      response = HTTParty.post("https://api.example.com/users", body: '{"name": "John"}', headers: { 'Content-Type' => 'application/json' })
+
+      _(response.code).must_equal 201
+
+      log = assert_request_logged(:post, "https://api.example.com/users", 201)
+      _(log.request_body).must_equal '{"name":"John"}'
+      _(log.response_body).must_equal '{"id":1,"name":"John"}'
+    end
+
+    it "logs requests with headers" do
+      stub_request(:get, "https://api.example.com/protected")
+        .with(headers: { 'Authorization' => 'Bearer token123' })
+        .to_return(status: 200, body: '{"data": "secret"}', headers: { 'Content-Type' => 'application/json' })
+
+      response = HTTParty.get("https://api.example.com/protected", headers: { 'Authorization' => 'Bearer token123' })
+
+      _(response.code).must_equal 200
+
+      log = assert_request_logged(:get, "https://api.example.com/protected", 200)
+      _(log.request_headers['authorization']).must_equal '[FILTERED]'
+    end
+
+    it "logs failed requests" do
+      stub_request(:get, "https://api.example.com/notfound")
+        .to_return(status: 404, body: '{"error": "Not found"}', headers: { 'Content-Type' => 'application/json' })
+
+      response = HTTParty.get("https://api.example.com/notfound")
+
+      _(response.code).must_equal 404
+
+      log = assert_request_logged(:get, "https://api.example.com/notfound", 404)
+      _(log.response_body).must_equal '{"error":"Not found"}'
+    end
+
+    it "skips excluded URLs" do
+      stub_request(:get, "https://api.example.com/health")
+        .to_return(status: 200, body: 'OK')
+
+      response = HTTParty.get("https://api.example.com/health")
+
+      _(response.code).must_equal 200
+      assert_no_request_logged
+    end
+
+    it "skips excluded content types" do
+      stub_request(:get, "https://api.example.com/page")
+        .to_return(status: 200, body: '<html></html>', headers: { 'Content-Type' => 'text/html' })
+
+      response = HTTParty.get("https://api.example.com/page")
+
+      _(response.code).must_equal 200
+      assert_no_request_logged
+    end
+
+    it "handles network errors gracefully" do
+      stub_request(:get, "https://api.example.com/error")
+        .to_raise(SocketError.new("Connection failed"))
+
+      _(proc { HTTParty.get("https://api.example.com/error") }).must_raise SocketError
+
+      log = assert_request_logged(:get, "https://api.example.com/error", 0)
+      _(log.response_body).must_include "SocketError"
+    end
+
+    it "prevents infinite recursion" do
+      stub_request(:get, "https://api.example.com/test")
+        .to_return(status: 200, body: 'OK')
+
+      3.times do
+        response = HTTParty.get("https://api.example.com/test")
+        _(response.code).must_equal 200
+      end
+
+      logs = OutboundHttpLogger::Models::OutboundRequestLog.where(url: "https://api.example.com/test")
+      _(logs.count).must_equal 6
+    end
+  end
+
+  describe "when logging is disabled" do
+    before do
+      OutboundHttpLogger.disable!
+    end
+
+    it "does not log requests when disabled" do
+      stub_request(:get, "https://api.example.com/users")
+        .to_return(status: 200, body: '{"users": []}')
+
+      response = HTTParty.get("https://api.example.com/users")
+
+      _(response.code).must_equal 200
+      assert_no_request_logged
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- depend on Faraday and HTTParty for testing
- cover Faraday and HTTParty patches with new tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_685a6181c3408322909191c4961fe573