### PR TITLE
Lower Ruby version & extend CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.4']
-        rails-version: ['7.2.0']
+        ruby-version: ['3.2', '3.3', '3.4']
+        rails-version: ['7.2.0', '8.1.0']
     
     steps:
       - name: Check out code
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          gem install rails -v ${{ matrix.rails-version }}
+          bundle update activerecord activesupport --conservative
           bundle install --jobs 4 --retry 3
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ rails generate outbound_http_logger:migration
 rails db:migrate
 ```
 
+### Compatibility
+
+This gem supports Ruby versions **3.2** and newer and is tested against
+Ruby 3.2, 3.3, and 3.4 on Rails 7.2 and 8.1.
+
 ## Configuration
 
 ### Basic Setup
@@ -532,7 +537,7 @@ The gem includes GitHub Actions workflows that automatically run on:
 - Pull requests targeting `develop` or `main` branches (when gem files change)
 
 The CI pipeline includes:
-- **Test Job**: Runs tests against Ruby 3.4 and Rails 7.2
+- **Test Job**: Runs tests against Ruby 3.2, 3.3, and 3.4 on Rails 7.2 and 8.1
 - **Build Job**: Validates gem can be built successfully
 - **Quality Job**: Runs RuboCop linting and validates gemspec
 - **Security Job**: Runs bundler-audit for dependency vulnerabilities

--- a/outbound_http_logger.gemspec
+++ b/outbound_http_logger.gemspec
@@ -12,7 +12,8 @@ Gem::Specification.new do |spec|
   spec.description           = "A gem for logging outbound HTTP requests with support for multiple HTTP libraries (Net::HTTP, Faraday, HTTParty), sensitive data filtering, and configurable exclusions."
   spec.homepage              = "https://github.com/getupgraded/outbound_http_logger"
   spec.license               = "MIT"
-  spec.required_ruby_version = ">= 3.4.0"
+  # Ruby 3.4 is not required; the gem works with Ruby 3.2+
+  spec.required_ruby_version = ">= 3.2.0"
 
   # Specify which files should be added to the gem when it is released.
   spec.files            = Dir.glob("{lib,test}/**/*") + %w[README.md Rakefile outbound_http_logger.gemspec]


### PR DESCRIPTION
## Summary
- relax gemspec to require Ruby >= 3.2
- document compatibility and updated test matrix in README
- expand GitHub Actions to test multiple Ruby and Rails versions

## Testing
- `bundle install --jobs 4 --retry 3`
- `bundle exec ruby -Ilib:test test/test_outbound_http_logger.rb`
- `bundle exec ruby -Ilib:test test/patches/test_net_http_patch.rb`
- `bundle exec ruby -Ilib:test test/concerns/test_outbound_logging.rb`
- `bundle exec ruby -Ilib:test test/integration/test_loggable_integration.rb`
- `bundle exec ruby -Ilib:test test/models/test_outbound_request_log.rb`
- `bundle exec rubocop --config .rubocop.yml` *(fails: 661 offenses)*
- `bundle-audit check --update` *(fails to clone advisory DB)*

------
https://chatgpt.com/codex/tasks/task_e_685a72ea00108322beae59666b0f2c24