### PR TITLE
Drop unnecessary field duration_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3
+
+- remove unnecessary duration_seconds column from database
+
 ## 0.0.2
 
 ### Code Quality Improvements

--- a/README.md
+++ b/README.md
@@ -250,6 +250,43 @@ recent_logs.each do |log|
 end
 ```
 
+### Duration API Flexibility
+
+The gem provides flexible duration APIs to accommodate different use cases and maintain consistency with sister gems:
+
+```ruby
+# Database storage: Always stored as duration_ms for precision
+log = OutboundHTTPLogger::Models::OutboundRequestLog.first
+
+# Reading duration in different units
+log.duration_ms       # => 1500.0 (milliseconds)
+log.duration_seconds  # => 1.5 (calculated from duration_ms)
+log.duration_in_seconds # => 1.5 (alias for compatibility)
+
+# Setting duration in different units
+log.duration_ms = 2000.0
+log.duration_seconds  # => 2.0
+
+log.duration_seconds = 3.5
+log.duration_ms       # => 3500.0
+
+# API methods uses seconds
+OutboundHTTPLogger::Models::OutboundRequestLog.log_request(
+  'POST', 'https://api.example.com/users',
+  request_data, response_data,
+  1.5024  # duration_seconds
+)
+
+
+
+```
+
+**Key Benefits:**
+- **Clean storage**: Only `duration_ms` is stored in the database for precision
+- **Flexible access**: Both millisecond and second APIs available for reading
+- **Sister gem consistency**: API accepts `duration_seconds` like `inbound_http_logger`
+- **Automatic conversion**: Seamless conversion from seconds to milliseconds for storage
+
 ## Test Utilities
 
 The gem provides a dedicated test namespace with powerful utilities for testing outbound HTTP request logging:
@@ -681,12 +718,12 @@ OutboundHTTPLogger::Models::OutboundRequestLog
 #### 3. Monitor Performance Impact
 
 ```ruby
-# Check average request duration
+# Check average request duration (in milliseconds)
 avg_duration = OutboundHTTPLogger::Models::OutboundRequestLog
   .where('created_at > ?', 1.day.ago)
-  .average(:duration_seconds)
+  .average(:duration_ms)
 
-puts "Average request duration: #{avg_duration}s"
+puts "Average request duration: #{avg_duration}ms"
 ```
 
 ### Scaling Considerations

--- a/lib/outbound_http_logger/database_adapters/base_adapter.rb
+++ b/lib/outbound_http_logger/database_adapters/base_adapter.rb
@@ -72,7 +72,7 @@ module OutboundHTTPLogger
       end
 
       # Log an outbound HTTP request to the database
-      def log_request(method, url, request_data = {}, response_data = {}, duration_seconds = 0, options = {})
+      def log_request(method, url, request_data = {}, response_data = {}, duration_seconds = nil, options = {})
         return nil unless enabled?
         return nil unless OutboundHTTPLogger.configuration.should_log_url?(url)
 

--- a/lib/outbound_http_logger/generators/templates/create_outbound_request_logs.rb
+++ b/lib/outbound_http_logger/generators/templates/create_outbound_request_logs.rb
@@ -24,7 +24,6 @@ class CreateOutboundRequestLogs < ActiveRecord::Migration<%= migration_version %
       end
 
       # Performance metrics
-      t.decimal :duration_seconds, precision: 10, scale: 6
       t.decimal :duration_ms, precision: 10, scale: 2
 
       # Polymorphic association for linking to other models

--- a/lib/outbound_http_logger/patches/common_patch_behavior.rb
+++ b/lib/outbound_http_logger/patches/common_patch_behavior.rb
@@ -177,12 +177,13 @@ module OutboundHTTPLogger
             return unless OutboundHTTPLogger.configuration.should_log_content_type?(content_type)
 
             duration_seconds = end_time - start_time
+            duration_ms = (duration_seconds * 1000).round(2)
             OutboundHTTPLogger.logger.log_completed_request(
               method,
               url,
               request_data,
               response_data,
-              duration_seconds
+              duration_ms
             )
           end
         end
@@ -191,6 +192,7 @@ module OutboundHTTPLogger
         def log_failed_request(method, url, library_specific_data, error, start_time, end_time, library_name = nil)
           OutboundHTTPLogger::ErrorHandling.handle_logging_error('log failed request') do
             duration_seconds = end_time - start_time
+            duration_ms = (duration_seconds * 1000).round(2)
             request_data = build_request_data(library_specific_data, library_name)
 
             response_data = {
@@ -204,7 +206,7 @@ module OutboundHTTPLogger
               url,
               request_data,
               response_data,
-              duration_seconds
+              duration_ms
             )
           end
         end

--- a/test/integration/test_rails_integration.rb
+++ b/test/integration/test_rails_integration.rb
@@ -126,7 +126,7 @@ describe 'Rails Integration Tests' do
       _(migration_content).must_include 't.json :request_body'
       _(migration_content).must_include 't.json :response_body'
       _(migration_content).must_include 't.json :metadata'
-      _(migration_content).must_include 't.decimal :duration_seconds'
+
       _(migration_content).must_include 't.decimal :duration_ms'
       _(migration_content).must_include 't.references :loggable, polymorphic: true'
       _(migration_content).must_include 't.timestamp :created_at'
@@ -206,7 +206,7 @@ describe 'Rails Integration Tests' do
       _(template_content).must_include 't.json :request_body'
       _(template_content).must_include 't.json :response_body'
       _(template_content).must_include 't.json :metadata'
-      _(template_content).must_include 't.decimal :duration_seconds'
+
       _(template_content).must_include 't.decimal :duration_ms'
       _(template_content).must_include 't.references :loggable, polymorphic: true'
       _(template_content).must_include 't.datetime :created_at'

--- a/test/integration/test_rake_tasks.rb
+++ b/test/integration/test_rake_tasks.rb
@@ -43,7 +43,6 @@ describe 'Rake Tasks Integration' do
         url: 'https://api.example.com/users',
         status_code: 200,
         duration_ms: 150.5,
-        duration_seconds: 0.1505,
         request_headers: { 'Accept' => 'application/json' },
         response_headers: { 'Content-Type' => 'application/json' },
         created_at: old_time


### PR DESCRIPTION
- Input compatibility with inbound_http_logger (accepts duration_seconds)
- Storage efficiency (only duration_ms in database)
- Output flexibility (both duration_ms and duration_seconds APIs)
- Observability consistency (uses seconds for standard metrics)